### PR TITLE
Fix cache mount issues

### DIFF
--- a/build.earth
+++ b/build.earth
@@ -1,24 +1,23 @@
 FROM golang:1.13-alpine3.11
 
 RUN apk add --update --no-cache \
-	openssl \
-	ca-certificates \
 	bash \
 	bash-completion \
-	util-linux \
-	grep \
-	less \
 	binutils \
-	findutils \
+	ca-certificates \
 	coreutils \
+	curl \
+	findutils \
+	g++ \
+	git \
+	grep \
 	grep \
 	less \
-	git \
-	g++ \
-	curl \
-	make
+	less \
+	make \
+	openssl \
+	util-linux
 
-ENV GOCACHE=/go-cache
 WORKDIR /earthly
 
 deps:
@@ -69,8 +68,8 @@ earth:
 	ARG EARTHLY_TARGET_TAG
 	ARG VERSION=$EARTHLY_TARGET_TAG
 	ARG DEFAULT_BUILDKITD_IMAGE=earthly/buildkitd:$VERSION
-	RUN \
-		--mount=type=cache,target=/go-cache \
+	ARG GOCACHE=/go-cache
+	RUN --mount=type=cache,target=$GOCACHE \
 		go build \
 			-ldflags "-X main.DefaultBuildkitdImage=$DEFAULT_BUILDKITD_IMAGE -X main.Version=$VERSION $GO_EXTRA_LDFLAGS" \
 			-o build/earth \

--- a/buildkitd/buildkitd.toml.template
+++ b/buildkitd/buildkitd.toml.template
@@ -5,12 +5,12 @@ insecure-entitlements = [ "security.insecure" ]
   enabled = true
   snapshotter = "auto"
   gc = true
-  # 1/100 of total cache size
+  # 1/100 of total cache size.
   gckeepstorage = :CACHE_SIZE_MB:0000
   [[worker.oci.gcpolicy]]
-    # 1/10 of total cache size
+    # 1/10 of total cache size.
     keepBytes = :CACHE_SIZE_MB:00000
-    filters = [ "type==source.local", "type==exec.cachemount", "type==source.git.checkout"]
+    filters = [ "type==source.local", "type==source.git.checkout"]
   [[worker.oci.gcpolicy]]
     all = true
     # Cache size MB with 6 zeros, to turn it into bytes.

--- a/cmd/earth/main.go
+++ b/cmd/earth/main.go
@@ -204,6 +204,7 @@ func newEarthApp(ctx context.Context, console conslogging.ConsoleLogger) *earthA
 		},
 		&cli.IntFlag{
 			Name:        "buildkit-cache-size-mb",
+			Value:       10000,
 			EnvVars:     []string{"EARTHLY_BUILDKIT_CACHE_SIZE_MB"},
 			Usage:       "The total size of the buildkit cache, in MB",
 			Destination: &app.buildkitdSettings.CacheSizeMb,
@@ -211,7 +212,7 @@ func newEarthApp(ctx context.Context, console conslogging.ConsoleLogger) *earthA
 		&cli.StringFlag{
 			Name:        "buildkit-image",
 			Value:       DefaultBuildkitdImage,
-			EnvVars:     []string{"EARTHLY_BUILDKITD_IMAGE"},
+			EnvVars:     []string{"EARTHLY_BUILDKIT_IMAGE"},
 			Usage:       "The docker image to use for the buildkit daemon",
 			Destination: &app.buildkitdImage,
 		},

--- a/docs/earth-command/earth-command.md
+++ b/docs/earth-command/earth-command.md
@@ -168,7 +168,7 @@ earth --buildkit-cache-size-mb <cache-size-mb> prune --reset
 
 ##### `--buildkit-image <bk-image>`
 
-Also available as an env var setting: `EARTHLY_BUILDKITD_IMAGE=<bk-image>`.
+Also available as an env var setting: `EARTHLY_BUILDKIT_IMAGE=<bk-image>`.
 
 Instructs earth to use an alternate image for buildkitd. The default image used is `earthly/buildkitd:<earth-version>`.
 

--- a/earthfile2llb/converter.go
+++ b/earthfile2llb/converter.go
@@ -219,15 +219,15 @@ func (c *Converter) CopyClassical(ctx context.Context, srcs []string, dest strin
 
 // Run applies the earth RUN command.
 func (c *Converter) Run(ctx context.Context, args []string, mounts []string, secretKeyValues []string, privileged bool, withEntrypoint bool, withDocker bool, isWithShell bool, pushFlag bool) error {
-	if !isWithShell {
-		// TODO: This does not work, because it strips away some quotes, which are valuable to the shell.
-		//       In any case, this is probably working as intended as is.
-		// for i := range args {
-		// 	args[i] = c.expandArgs(args[i])
-		// }
-		for i := range mounts {
-			mounts[i] = c.expandArgs(mounts[i])
-		}
+	// TODO: This does not work, because it strips away some quotes, which are valuable to the shell.
+	//       In any case, this is probably working as intended as is.
+	// if !isWithShell {
+	// 	for i := range args {
+	// 		args[i] = c.expandArgs(args[i])
+	// 	}
+	// }
+	for i := range mounts {
+		mounts[i] = c.expandArgs(mounts[i])
 	}
 	logging.GetLogger(ctx).
 		With("args", args).
@@ -954,6 +954,9 @@ func makeCacheContext(target domain.Target) llb.State {
 }
 
 func cacheKey(target domain.Target) string {
-	digest := sha256.Sum256([]byte(target.StringCanonical()))
+	// Use the canonical target, but wihout the tag for cache matching.
+	targetCopy := target
+	targetCopy.Tag = ""
+	digest := sha256.Sum256([]byte(targetCopy.StringCanonical()))
 	return hex.EncodeToString(digest[:])
 }

--- a/earthfile2llb/runmount.go
+++ b/earthfile2llb/runmount.go
@@ -137,7 +137,7 @@ func parseMount(mount string, target domain.Target, ti dedup.TargetInput, cacheC
 }
 
 func cacheKeyTargetInput(ti dedup.TargetInput) (string, error) {
-	digest, err := ti.Hash()
+	digest, err := ti.HashNoTag()
 	if err != nil {
 		return "", errors.Wrapf(err, "compute hash key for %s", ti.TargetCanonical)
 	}

--- a/examples/tests/build.earth
+++ b/examples/tests/build.earth
@@ -20,46 +20,40 @@ experimental:
 
 privileged-test:
 	COPY privileged.earth ./build.earth
-	RUN \
-		--mount=type=cache,target=/tmp/earthly \
+	RUN --mount=type=cache,target=/tmp/earthly \
 		--privileged \
 		--entrypoint \
 		-- --allow-privileged +test
 
 cache-test:
 	COPY cache1.earth ./build.earth
-	RUN \
-		--mount=type=cache,target=/tmp/earthly \
+	RUN --mount=type=cache,target=/tmp/earthly \
 		--privileged \
 		--entrypoint \
 		-- +test
 	COPY cache2.earth ./build.earth
-	RUN \
-		--mount=type=cache,target=/tmp/earthly \
+	RUN --mount=type=cache,target=/tmp/earthly \
 		--privileged \
 		--entrypoint \
 		-- +test
 
 git-clone-test:
 	COPY git-clone.earth ./build.earth
-	RUN \
-		--mount=type=cache,target=/tmp/earthly \
+	RUN --mount=type=cache,target=/tmp/earthly \
 		--privileged \
 		--entrypoint \
 		-- +test
 
 builtin-args-test:
 	COPY builtin-args.earth ./build.earth
-	RUN \
-		--mount=type=cache,target=/tmp/earthly \
+	RUN --mount=type=cache,target=/tmp/earthly \
 		--privileged \
 		--entrypoint \
 		-- +builtin-args-test
 
 config-test:
 	COPY config.earth ./build.earth
-	RUN \
-		--mount=type=cache,target=/tmp/earthly \
+	RUN --mount=type=cache,target=/tmp/earthly \
 		--privileged \
 		--entrypoint \
 		-- +test
@@ -69,8 +63,7 @@ excludes-test:
 	RUN touch exclude-me.txt
 	RUN touch do-not-exclude-me.txt
 	RUN echo 'exclude-me.txt' > .earthignore
-	RUN \
-		--mount=type=cache,target=/tmp/earthly \
+	RUN --mount=type=cache,target=/tmp/earthly \
 		--privileged \
 		--entrypoint \
 		-- +test
@@ -79,16 +72,14 @@ secrets-test:
 	COPY secrets.earth ./build.earth
 	ENV SECRET1=foo
 	ENV SECRET2=wrong
-	RUN \
-		--mount=type=cache,target=/tmp/earthly \
+	RUN --mount=type=cache,target=/tmp/earthly \
 		--privileged \
 		--entrypoint \
 		-- --secret SECRET1 --secret SECRET2=bar +test
 
 build-arg-test:
 	COPY build-arg.earth ./build.earth
-	RUN \
-		--mount=type=cache,target=/tmp/earthly \
+	RUN --mount=type=cache,target=/tmp/earthly \
 		--privileged \
 		--entrypoint \
 		-- +test
@@ -96,8 +87,7 @@ build-arg-test:
 # TODO: This does not pass.
 transitive-args-test-todo:
 	COPY transitive-args.earth ./build.earth
-	RUN \
-		--mount=type=cache,target=/tmp/earthly \
+	RUN --mount=type=cache,target=/tmp/earthly \
 		--privileged \
 		--entrypoint \
 		-- --build-arg SOMEARG=def +test
@@ -111,8 +101,7 @@ build-github-test:
 star-test:
 	COPY star.earth ./build.earth
 	RUN touch a.txt b.txt c.nottxt
-	RUN \
-		--mount=type=cache,target=/tmp/earthly \
+	RUN --mount=type=cache,target=/tmp/earthly \
 		--privileged \
 		--entrypoint \
 		-- +test
@@ -121,14 +110,12 @@ star-test:
 star-test-todo:
 	COPY star.earth ./build.earth
 	RUN touch a.txt b.txt c.nottxt
-	RUN \
-		--mount=type=cache,target=/tmp/earthly \
+	RUN --mount=type=cache,target=/tmp/earthly \
 		--privileged \
 		--entrypoint \
 		-- +test
 	RUN echo "a change" > c.nottxt
-	RUN \
-		--mount=type=cache,target=/tmp/earthly \
+	RUN --mount=type=cache,target=/tmp/earthly \
 		--privileged \
 		--entrypoint \
 		-- +test >output.txt
@@ -139,24 +126,21 @@ star-test-todo:
 
 docker-load-test:
 	COPY docker-load.earth ./build.earth
-	RUN \
-		--mount=type=cache,target=/tmp/earthly \
+	RUN --mount=type=cache,target=/tmp/earthly \
 		--privileged \
 		--entrypoint \
 		-- --allow-privileged +test
 
 dind-test:
 	COPY dind.earth ./build.earth
-	RUN \
-		--mount=type=cache,target=/tmp/earthly \
+	RUN --mount=type=cache,target=/tmp/earthly \
 		--privileged \
 		--entrypoint \
 		-- --allow-privileged +test
 
 docker-pull-test:
 	COPY docker-pull.earth ./build.earth
-	RUN \
-		--mount=type=cache,target=/tmp/earthly \
+	RUN --mount=type=cache,target=/tmp/earthly \
 		--privileged \
 		--entrypoint \
 		-- --allow-privileged +test

--- a/examples/tests/cache2.earth
+++ b/examples/tests/cache2.earth
@@ -1,3 +1,4 @@
 FROM alpine:3.11
 test:
     RUN --mount=type=cache,target=/cache-test test -f /cache-test/test.txt
+    RUN --mount=type=cache,target=/cache-test cat /cache-test/test.txt


### PR DESCRIPTION
* Mount params not args-expanded
* Cache key dependent on tag (which changes with every branch switch, causing frequent cache bust)
* Cache size for cache mounts too small, causing frequent GC of it

Note that this will break build temporarily as new build definition uses arg in cache mount.
